### PR TITLE
publish and publishroot accept strings and now objects

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -41,25 +41,33 @@ module.exports = class Node {
 
   // Publish data to the network
   //
-  // @param {Object} data
+  // @param {Object} data which should be JSON.stringify-able
   //
   // @return {Promise} Node
   //
   publish(data) {
+    let dataString = data
+    if (typeof data !== 'string') {
+      dataString = JSON.stringify(data)
+    }
     log.info(`${MODULE_NAME}: Publishing new data`)
-    return publish(data, this)
+    return publish(dataString, this)
       .catch(passOrDie(MODULE_NAME))
   }
 
   // Publish the node's data root to the network
   //
-  // @param {Object} data
+  // @param {Object} data which should be JSON.stringify-able
   //
   // @return {Promise} Node
   //
   publishRoot(data) {
+    let dataString = data
+    if (typeof data !== 'string') {
+      dataString = JSON.stringify(data)
+    }
     log.info(`${MODULE_NAME}: Publishing new root`)
-    return publishRoot(data, this)
+    return publishRoot(dataString, this)
       .catch(passOrDie(MODULE_NAME))
   }
 

--- a/test/blackbox.spec.js
+++ b/test/blackbox.spec.js
@@ -43,12 +43,16 @@ describe('Black box test of publish then subscribe:', () => {
       node.prepareToPublish().then(() => { done() })
     })
 
-    it('should succeed when publishing a root message', (done) => {
+    it('should succeed when publishing a string root message', (done) => {
       node.publishRoot('root message').then(() => { done() })
     })
 
-    it('should succeed when publishing a message after publishing a root message', (done) => {
+    it('should succeed when publishing a string message after publishing a root message', (done) => {
       node.publish('second message').then(() => { done() })
+    })
+
+    it('should succeed when publishing a javascript object message', (done) => {
+      node.publish({message: 'message as object'}).then(() => { done() })
     })
   })
 


### PR DESCRIPTION
node.publish and node.publishRoot previously only accepted an argument of type string. They now accept objects to and call JSON.stringify before passing on to publish module.